### PR TITLE
Update lodash dependency and modernize usage.

### DIFF
--- a/Generator.js
+++ b/Generator.js
@@ -124,7 +124,7 @@ module.exports = {
     var NEW_FORM_FIELDS_TEMPLATE = path.resolve(__dirname, './templates/newFormFields.template');
     NEW_FORM_FIELDS_TEMPLATE = fs.readFileSync(NEW_FORM_FIELDS_TEMPLATE, 'utf8');
 
-    var compiledNewFormFields = _.template(NEW_FORM_FIELDS_TEMPLATE, {
+    var compiledNewFormFields = _.template(NEW_FORM_FIELDS_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -139,7 +139,7 @@ module.exports = {
     var NEW_FLASH_TEMPLATE = path.resolve(__dirname, './templates/newFlash.template');
     NEW_FLASH_TEMPLATE = fs.readFileSync(NEW_FLASH_TEMPLATE, 'utf8');
 
-    var compiledNewFlash = _.template(NEW_FLASH_TEMPLATE, {
+    var compiledNewFlash = _.template(NEW_FLASH_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -172,7 +172,7 @@ module.exports = {
     var SHOW_FORM_FIELDS_TEMPLATE = path.resolve(__dirname, './templates/showFormFields.template');
     SHOW_FORM_FIELDS_TEMPLATE = fs.readFileSync(SHOW_FORM_FIELDS_TEMPLATE, 'utf8');
 
-    var compiledShowFormFields = _.template(SHOW_FORM_FIELDS_TEMPLATE, {
+    var compiledShowFormFields = _.template(SHOW_FORM_FIELDS_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -191,7 +191,7 @@ module.exports = {
     var SHOW_EDIT_LINK_TEMPLATE = path.resolve(__dirname, './templates/showEditLink.template');
     SHOW_EDIT_LINK_TEMPLATE = fs.readFileSync(SHOW_EDIT_LINK_TEMPLATE, 'utf8');
 
-    var compiledShowEditLink = _.template(SHOW_EDIT_LINK_TEMPLATE, {
+    var compiledShowEditLink = _.template(SHOW_EDIT_LINK_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -221,7 +221,7 @@ module.exports = {
     var INDEX_TABLE_HEADINGS_TEMPLATE = path.resolve(__dirname, './templates/indexTableHeadings.template');
     INDEX_TABLE_HEADINGS_TEMPLATE = fs.readFileSync(INDEX_TABLE_HEADINGS_TEMPLATE, 'utf8');
 
-    var compiledIndexTableHeadings = _.template(INDEX_TABLE_HEADINGS_TEMPLATE, {
+    var compiledIndexTableHeadings = _.template(INDEX_TABLE_HEADINGS_TEMPLATE)({
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName
@@ -236,7 +236,7 @@ module.exports = {
     var INDEX_TABLE_DATA_TEMPLATE = path.resolve(__dirname, './templates/indexTableData.template');
     INDEX_TABLE_DATA_TEMPLATE = fs.readFileSync(INDEX_TABLE_DATA_TEMPLATE, 'utf8');
 
-    var compiledIndexTableData = _.template(INDEX_TABLE_DATA_TEMPLATE, {
+    var compiledIndexTableData = _.template(INDEX_TABLE_DATA_TEMPLATE)({
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName,
@@ -261,7 +261,7 @@ module.exports = {
     var INDEX_FOR_EACH_TEMPLATE = path.resolve(__dirname, './templates/indexForEach.template');
     INDEX_FOR_EACH_TEMPLATE = fs.readFileSync(INDEX_FOR_EACH_TEMPLATE, 'utf8');
 
-    var compiledIndexForEach = _.template(INDEX_FOR_EACH_TEMPLATE, {
+    var compiledIndexForEach = _.template(INDEX_FOR_EACH_TEMPLATE)({
       compiledIndexTableData: compiledIndexTableData,
       modelControllerNamePluralized: scope.modelControllerNamePluralized,
       modelControllerName: scope.modelControllerName
@@ -292,7 +292,7 @@ module.exports = {
     var EDIT_FORM_FIELDS_TEMPLATE = path.resolve(__dirname, './templates/editFormFields.template');
     EDIT_FORM_FIELDS_TEMPLATE = fs.readFileSync(EDIT_FORM_FIELDS_TEMPLATE, 'utf8');
 
-    var compiledEditFormFields = _.template(EDIT_FORM_FIELDS_TEMPLATE, {
+    var compiledEditFormFields = _.template(EDIT_FORM_FIELDS_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       modelControllerName: scope.modelControllerName
     });
@@ -309,7 +309,7 @@ module.exports = {
     var EDIT_FLASH_TEMPLATE = path.resolve(__dirname, './templates/editFlash.template');
     EDIT_FLASH_TEMPLATE = fs.readFileSync(EDIT_FLASH_TEMPLATE, 'utf8');
 
-    var compiledEditFlash = _.template(EDIT_FLASH_TEMPLATE, {
+    var compiledEditFlash = _.template(EDIT_FLASH_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -328,7 +328,7 @@ module.exports = {
     var EDIT_FORM_ACTION_TEMPLATE = path.resolve(__dirname, './templates/editFormAction.template');
     EDIT_FORM_ACTION_TEMPLATE = fs.readFileSync(EDIT_FORM_ACTION_TEMPLATE, 'utf8');
 
-    var compiledEditFormAction = _.template(EDIT_FORM_ACTION_TEMPLATE, {
+    var compiledEditFormAction = _.template(EDIT_FORM_ACTION_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       modelControllerName: scope.modelControllerName
     });
@@ -345,7 +345,7 @@ module.exports = {
     var EDIT_SHOW_LINK_TEMPLATE = path.resolve(__dirname, './templates/editShowLink.template');
     EDIT_SHOW_LINK_TEMPLATE = fs.readFileSync(EDIT_SHOW_LINK_TEMPLATE, 'utf8');
 
-    var compiledEditShowLink = _.template(EDIT_SHOW_LINK_TEMPLATE, {
+    var compiledEditShowLink = _.template(EDIT_SHOW_LINK_TEMPLATE)({
       modelAttributeNames: scope.modelAttributeNames,
       id: scope.id,
       modelControllerName: scope.modelControllerName
@@ -375,7 +375,7 @@ module.exports = {
     var ACTION_PARAM_OBJECT_TEMPLATE = path.resolve(__dirname, './templates/actionParamObject.template');
     ACTION_PARAM_OBJECT_TEMPLATE = fs.readFileSync(ACTION_PARAM_OBJECT_TEMPLATE, 'utf8');
 
-    var compliledActionParamObject = _.template(ACTION_PARAM_OBJECT_TEMPLATE, {
+    var compliledActionParamObject = _.template(ACTION_PARAM_OBJECT_TEMPLATE)({
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName
@@ -385,7 +385,7 @@ module.exports = {
     var ACTION_UPDATE_PARAM_OBJECT_TEMPLATE = path.resolve(__dirname, './templates/actionUpdateParamObject.template');
     ACTION_UPDATE_PARAM_OBJECT_TEMPLATE = fs.readFileSync(ACTION_UPDATE_PARAM_OBJECT_TEMPLATE, 'utf8');
 
-    var compliledActionUpdateParamObject = _.template(ACTION_UPDATE_PARAM_OBJECT_TEMPLATE, {
+    var compliledActionUpdateParamObject = _.template(ACTION_UPDATE_PARAM_OBJECT_TEMPLATE)({
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName
@@ -397,7 +397,7 @@ module.exports = {
     var ACTION_TEMPLATE = path.resolve(__dirname, './templates/action.template');
     ACTION_TEMPLATE = fs.readFileSync(ACTION_TEMPLATE, 'utf8');
 
-    var compliledActions = _.template(ACTION_TEMPLATE, {
+    var compliledActions = _.template(ACTION_TEMPLATE)({
         compliledActionParamObject: compliledActionParamObject,
         compliledActionUpdateParamObject: compliledActionUpdateParamObject,
         id: scope.id,
@@ -410,7 +410,7 @@ module.exports = {
     var HOMEPAGE_EJS_TEMPLATE = path.resolve(__dirname, './templates/homePageEJS.template');
     HOMEPAGE_EJS_TEMPLATE = fs.readFileSync(HOMEPAGE_EJS_TEMPLATE, 'utf8');
 
-    var compliledHomePageEJS = _.template(HOMEPAGE_EJS_TEMPLATE, {});
+    var compliledHomePageEJS = _.template(HOMEPAGE_EJS_TEMPLATE)({});
 
     // This puts erb style delimeters
     compliledHomePageEJS = compliledHomePageEJS.replace(/ERBstart=/g, '<%=')

--- a/Generator.js
+++ b/Generator.js
@@ -60,7 +60,7 @@ module.exports = {
 
       // $sails generate scaffold user  --> id returns User
       id: _.str.capitalize(scope.args[0]),
-
+      viewDirectoryName: scope.args[0],
       // $sails generate scaffold user  --> modelControllerName returns user
       modelControllerName: scope.args[0],
 
@@ -448,13 +448,13 @@ module.exports = {
 
    './views/homepage.ejs': {template: {templatePath: 'homePage.template', force: true } },
 
-    './views/:id/new.ejs': {template: {templatePath: 'new.template', force: true } },
+    './views/:viewDirectoryName/new.ejs': {template: {templatePath: 'new.template', force: true } },
 
-    './views/:id/show.ejs': {template: {templatePath: 'show.template', force: true } },
+    './views/:viewDirectoryName/show.ejs': {template: {templatePath: 'show.template', force: true } },
 
-    './views/:id/index.ejs': {template: {templatePath: 'index.template', force: true } },
+    './views/:viewDirectoryName/index.ejs': {template: {templatePath: 'index.template', force: true } },
 
-    './views/:id/edit.ejs': {template: {templatePath: 'edit.template', force: true } },
+    './views/:viewDirectoryName/edit.ejs': {template: {templatePath: 'edit.template', force: true } },
 
     './api/policies/flash.js': {template: {templatePath: 'flashPolicy.template', force: true} },
 

--- a/Generator.js
+++ b/Generator.js
@@ -99,25 +99,25 @@ module.exports = {
     });
 
     // Pluck just the name values
-    var modelAttributeNames = _.pluck(scope.modelAttributes, 'name');
+    var modelAttributeNames = _.map(scope.modelAttributes, 'name');
 
     // Add the optional model attribute names to the scope
     _.defaults(scope, {
       modelAttributeNames: modelAttributeNames
-    });   
+    });
 
 /**
 
-                    __      ___            _______                   _       _       
-                    \ \    / (_)          |__   __|                 | |     | |      
-  _ __   _____      _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___ 
+                    __      ___            _______                   _       _
+                    \ \    / (_)          |__   __|                 | |     | |
+  _ __   _____      _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___
  | '_ \ / _ \ \ /\ / /\ \/ / | |/ _ \ \ /\ / / |/ _ \ '_ ` _ \| '_ \| |/ _` | __/ _ \
  | | | |  __/\ V  V /  \  /  | |  __/\ V  V /| |  __/ | | | | | |_) | | (_| | ||  __/
  |_| |_|\___| \_/\_/    \/   |_|\___| \_/\_/ |_|\___|_| |_| |_| .__/|_|\__,_|\__\___|
-                                                              | |                    
-                                                              |_|                    
+                                                              | |
+                                                              |_|
 
-**/                                          
+**/
 
     // This generates a template using the newFormFields.template located in scaffold/templates
     // combined with modelAttributeNames to produce form fields for the new view derived from the model attributes
@@ -133,11 +133,11 @@ module.exports = {
     // Add the compiled new form fields to the scope
     _.defaults(scope, {
       compiledNewFormFields: compiledNewFormFields
-    });    
+    });
 
     //This generates a template using newFlash.template
     var NEW_FLASH_TEMPLATE = path.resolve(__dirname, './templates/newFlash.template');
-    NEW_FLASH_TEMPLATE = fs.readFileSync(NEW_FLASH_TEMPLATE, 'utf8'); 
+    NEW_FLASH_TEMPLATE = fs.readFileSync(NEW_FLASH_TEMPLATE, 'utf8');
 
     var compiledNewFlash = _.template(NEW_FLASH_TEMPLATE, {
       modelAttributeNames: scope.modelAttributeNames,
@@ -145,7 +145,7 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     })
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledNewFlash = compiledNewFlash.replace(/ERBstart/g, '<%')
     compiledNewFlash = compiledNewFlash.replace(/ERBend/g, '%>')
 
@@ -156,15 +156,15 @@ module.exports = {
 
 /**
 
-      _                 __      ___            _______                   _       _       
-     | |                \ \    / (_)          |__   __|                 | |     | |      
-  ___| |__   _____      _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___ 
+      _                 __      ___            _______                   _       _
+     | |                \ \    / (_)          |__   __|                 | |     | |
+  ___| |__   _____      _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___
  / __| '_ \ / _ \ \ /\ / /\ \/ / | |/ _ \ \ /\ / / |/ _ \ '_ ` _ \| '_ \| |/ _` | __/ _ \
  \__ \ | | | (_) \ V  V /  \  /  | |  __/\ V  V /| |  __/ | | | | | |_) | | (_| | ||  __/
  |___/_| |_|\___/ \_/\_/    \/   |_|\___| \_/\_/ |_|\___|_| |_| |_| .__/|_|\__,_|\__\___|
-                                                                  | |                    
-                                                                  |_|                    
-**/     
+                                                                  | |
+                                                                  |_|
+**/
 
 
     // This generates a template using the showFormFields.template located in scaffold/templates
@@ -178,14 +178,14 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     })
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledShowFormFields = compiledShowFormFields.replace(/ERBstart/g, '<%=')
     compiledShowFormFields = compiledShowFormFields.replace(/ERBend/g, '%>')
 
     // Add the compiled show form fields to the scope
     _.defaults(scope, {
       compiledShowFormFields: compiledShowFormFields
-    }); 
+    });
 
     // This generates a template using the showEditLink.template located in scaffold/templates
     var SHOW_EDIT_LINK_TEMPLATE = path.resolve(__dirname, './templates/showEditLink.template');
@@ -197,7 +197,7 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     })
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledShowEditLink = compiledShowEditLink.replace(/ERBstart/g, '<%=')
     compiledShowEditLink = compiledShowEditLink.replace(/ERBend/g, '%>')
 
@@ -207,15 +207,15 @@ module.exports = {
 
 /**
 
-  _           _         __      ___            _______                   _       _       
- (_)         | |        \ \    / (_)          |__   __|                 | |     | |      
-  _ _ __   __| | _____  _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___ 
+  _           _         __      ___            _______                   _       _
+ (_)         | |        \ \    / (_)          |__   __|                 | |     | |
+  _ _ __   __| | _____  _\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___
  | | '_ \ / _` |/ _ \ \/ /\ \/ / | |/ _ \ \ /\ / / |/ _ \ '_ ` _ \| '_ \| |/ _` | __/ _ \
  | | | | | (_| |  __/>  <  \  /  | |  __/\ V  V /| |  __/ | | | | | |_) | | (_| | ||  __/
  |_|_| |_|\__,_|\___/_/\_\  \/   |_|\___| \_/\_/ |_|\___|_| |_| |_| .__/|_|\__,_|\__\___|
-                                                                  | |                    
-                                                                  |_|                                        
-**/ 
+                                                                  | |
+                                                                  |_|
+**/
 
     // This generates the table index headings using indexTableHeadings.template located in scaffold/templates
     var INDEX_TABLE_HEADINGS_TEMPLATE = path.resolve(__dirname, './templates/indexTableHeadings.template');
@@ -246,16 +246,16 @@ module.exports = {
 
     _.defaults(scope, {
         modelControllerNamePluralized: scope.modelControllerName + 's'
-    }); 
+    });
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledIndexTableData = compiledIndexTableData.replace(/ERBstart/g, '<%=')
     compiledIndexTableData = compiledIndexTableData.replace(/ERBend/g, '%>')
 
     // Add the compiled show form fields to the scope
     _.defaults(scope, {
       compiledIndexTableData: compiledIndexTableData
-    }); 
+    });
 
     // This generates the indexForEach template
     var INDEX_FOR_EACH_TEMPLATE = path.resolve(__dirname, './templates/indexForEach.template');
@@ -267,7 +267,7 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     });
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledIndexForEach = compiledIndexForEach.replace(/ERBstart/g, '<%')
     compiledIndexForEach = compiledIndexForEach.replace(/ERBend/g, '%>')
 
@@ -277,16 +277,16 @@ module.exports = {
 
 /**
 
-           _ _ ___      ___            _______                   _       _       
-          | (_) \ \    / (_)          |__   __|                 | |     | |      
-   ___  __| |_| |\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___ 
+           _ _ ___      ___            _______                   _       _
+          | (_) \ \    / (_)          |__   __|                 | |     | |
+   ___  __| |_| |\ \  / / _  _____      _| | ___ _ __ ___  _ __ | | __ _| |_ ___
   / _ \/ _` | | __\ \/ / | |/ _ \ \ /\ / / |/ _ \ '_ ` _ \| '_ \| |/ _` | __/ _ \
  |  __/ (_| | | |_ \  /  | |  __/\ V  V /| |  __/ | | | | | |_) | | (_| | ||  __/
   \___|\__,_|_|\__| \/   |_|\___| \_/\_/ |_|\___|_| |_| |_| .__/|_|\__,_|\__\___|
-                                                          | |                    
-                                                          |_|                    
+                                                          | |
+                                                          |_|
 
-**/ 
+**/
 
     // This generates the editFormFields template
     var EDIT_FORM_FIELDS_TEMPLATE = path.resolve(__dirname, './templates/editFormFields.template');
@@ -297,7 +297,7 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     });
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledEditFormFields = compiledEditFormFields.replace(/ERBstart/g, '<%=')
     compiledEditFormFields = compiledEditFormFields.replace(/ERBend/g, '%>')
 
@@ -307,7 +307,7 @@ module.exports = {
 
     //This generates a template using editFlash.template
     var EDIT_FLASH_TEMPLATE = path.resolve(__dirname, './templates/editFlash.template');
-    EDIT_FLASH_TEMPLATE = fs.readFileSync(EDIT_FLASH_TEMPLATE, 'utf8'); 
+    EDIT_FLASH_TEMPLATE = fs.readFileSync(EDIT_FLASH_TEMPLATE, 'utf8');
 
     var compiledEditFlash = _.template(EDIT_FLASH_TEMPLATE, {
       modelAttributeNames: scope.modelAttributeNames,
@@ -315,7 +315,7 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     })
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledEditFlash = compiledEditFlash.replace(/ERBstart/g, '<%')
     compiledEditFlash = compiledEditFlash.replace(/ERBend/g, '%>')
 
@@ -333,13 +333,13 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     });
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledEditFormAction = compiledEditFormAction.replace(/ERBstart/g, '<%=')
     compiledEditFormAction = compiledEditFormAction.replace(/ERBend/g, '%>')
 
     _.defaults(scope, {
       compiledEditFormAction: compiledEditFormAction
-    }); 
+    });
 
     // This generates a template using the editShowLink.template located in scaffold/templates
     var EDIT_SHOW_LINK_TEMPLATE = path.resolve(__dirname, './templates/editShowLink.template');
@@ -351,24 +351,24 @@ module.exports = {
       modelControllerName: scope.modelControllerName
     })
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compiledEditShowLink = compiledEditShowLink.replace(/ERBstart/g, '<%=')
     compiledEditShowLink = compiledEditShowLink.replace(/ERBend/g, '%>')
 
     _.defaults(scope, {
       compiledEditShowLink: compiledEditShowLink
-    });  
+    });
 
 /**
-             _   _          _______                   _       _       
-            | | (_)        |__   __|                 | |     | |      
-   __ _  ___| |_ _  ___  _ __ | | ___ _ __ ___  _ __ | | __ _| |_ ___ 
+             _   _          _______                   _       _
+            | | (_)        |__   __|                 | |     | |
+   __ _  ___| |_ _  ___  _ __ | | ___ _ __ ___  _ __ | | __ _| |_ ___
   / _` |/ __| __| |/ _ \| '_ \| |/ _ \ '_ ` _ \| '_ \| |/ _` | __/ _ \
  | (_| | (__| |_| | (_) | | | | |  __/ | | | | | |_) | | (_| | ||  __/
   \__,_|\___|\__|_|\___/|_| |_|_|\___|_| |_| |_| .__/|_|\__,_|\__\___|
-                                               | |                    
-                                               |_|                                                                                            
-**/  
+                                               | |
+                                               |_|
+**/
 
     // This generates a template using the actionParamObject.template located in scaffold/templates
     // to produce a the params to include.
@@ -379,7 +379,7 @@ module.exports = {
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName
-    })  
+    })
 
     // This generates a template using the actionUpdateParamObject.template
     var ACTION_UPDATE_PARAM_OBJECT_TEMPLATE = path.resolve(__dirname, './templates/actionUpdateParamObject.template');
@@ -389,9 +389,9 @@ module.exports = {
         modelAttributeNames: scope.modelAttributeNames,
         id: scope.id,
         modelControllerName: scope.modelControllerName
-    }) 
+    })
 
-    
+
     // This generates a template using the action.template located in scaffold/templates
     // combined with CRUD actions to produce a controller.
     var ACTION_TEMPLATE = path.resolve(__dirname, './templates/action.template');
@@ -410,16 +410,16 @@ module.exports = {
     var HOMEPAGE_EJS_TEMPLATE = path.resolve(__dirname, './templates/homePageEJS.template');
     HOMEPAGE_EJS_TEMPLATE = fs.readFileSync(HOMEPAGE_EJS_TEMPLATE, 'utf8');
 
-    var compliledHomePageEJS = _.template(HOMEPAGE_EJS_TEMPLATE, {});  
+    var compliledHomePageEJS = _.template(HOMEPAGE_EJS_TEMPLATE, {});
 
-    // This puts erb style delimeters 
+    // This puts erb style delimeters
     compliledHomePageEJS = compliledHomePageEJS.replace(/ERBstart=/g, '<%=')
     compliledHomePageEJS = compliledHomePageEJS.replace(/ERBstart/g, '<%')
     compliledHomePageEJS = compliledHomePageEJS.replace(/ERBend/g, '%>')
 
     _.defaults(scope, {
       compliledHomePageEJS: compliledHomePageEJS
-    });   
+    });
 
     // When finished, we trigger a callback with no error
     // to begin generating files/folders as specified by
@@ -444,9 +444,9 @@ module.exports = {
 
    './assets/styles/custom.css': {template: {templatePath: 'customCSS.template', force: true } },
 
-   './assets/styles/bootstrapScaffold.css': {template: {templatePath: 'bootstrapScaffoldCSS.template', force: true } },  
+   './assets/styles/bootstrapScaffold.css': {template: {templatePath: 'bootstrapScaffoldCSS.template', force: true } },
 
-   './views/homepage.ejs': {template: {templatePath: 'homePage.template', force: true } }, 
+   './views/homepage.ejs': {template: {templatePath: 'homePage.template', force: true } },
 
     './views/:id/new.ejs': {template: {templatePath: 'new.template', force: true } },
 
@@ -458,7 +458,7 @@ module.exports = {
 
     './api/policies/flash.js': {template: {templatePath: 'flashPolicy.template', force: true} },
 
-    './config/scaffold-policies.js': {template: {templatePath: 'policies.template', force: true} }    
+    './config/scaffold-policies.js': {template: {templatePath: 'policies.template', force: true} }
 
 
   },

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sails-generate-scaffold
 
-###**Note:** This module requires Sails **v0.10.0-rc8** or higher.
+**Note:** This module requires Sails **v0.10.0-rc8** or higher.
 
 A `scaffold` generator for use with the Sails command-line interface.  A `scaffold` generates a rudimentary model, CRUD controller actions (e.g. index, new, create, edit, update, and destroy), and corresponding views of a Sails project.   The `scaffold` generator will also create a policy that enables flash messages for errors on the new and edit views. 
 
@@ -45,7 +45,7 @@ The first argument will be the `model` and `controller` name.  You can add any n
 - [Twitter](https://twitter.com/sailsjs)
 - [Professional/enterprise](https://github.com/balderdashy/sails-docs/blob/master/FAQ.md#are-there-professional-support-options)
 - [Tutorials](https://github.com/balderdashy/sails-docs/blob/master/FAQ.md#where-do-i-get-help)
-- <a href="http://sailsjs.org" target="_blank" title="Node.js framework for building realtime APIs."><img src="https://github-camo.global.ssl.fastly.net/9e49073459ed4e0e2687b80eaf515d87b0da4a6b/687474703a2f2f62616c64657264617368792e6769746875622e696f2f7361696c732f696d616765732f6c6f676f2e706e67" width=60 alt="Sails.js logo (small)"/></a>
+- <a href="http://sailsjs.org" target="_blank" title="Node.js framework for building realtime APIs.">SailsJs.org</a>
 
 
 ### License

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "author": "Irl Nathan",
   "license": "MIT",
   "dependencies": {
-  	"lodash": ">=2.4.x",
-  	"merge-defaults": ">=0.1.0",
+    "lodash": "^4.17.4",
+    "merge-defaults": ">=0.1.0",
     "underscore.string": "^2.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-generate-scaffold",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "sails generate scaffold",
   "main": "Generator.js",
   "scripts": {

--- a/templates/editFormFields.template
+++ b/templates/editFormFields.template
@@ -1,6 +1,6 @@
 <% _.forEach(modelAttributeNames, function (name) { %>
 	<div class="form-group" style="width: 400px;">
-	<label>name</label>
+	<label><%= name %></label>
 	<input value="ERBstart <%= modelControllerName %>.<%= name %> ERBend" name="<%= name %>" type="text" class="form-control"/>
 	</div>
 <% }) %>

--- a/templates/showFormFields.template
+++ b/templates/showFormFields.template
@@ -1,6 +1,6 @@
 <% _.forEach(modelAttributeNames, function (name) { %>
 	<div class="form-group" style="width: 400px;">
-	<label>name</label>
+	<label><%= name %></label>
 	<input value="ERBstart <%= modelControllerName %>.<%= name %> ERBend" name="<%= name %>" type="text" class="form-control" disabled/>
 	</div>
 <% }) %>


### PR DESCRIPTION
## Summary
I needed to get this to work with a more current `lodash` version, so that it would be compatible with Sails v0.12.

My editor auto-stripped the trailing whitespace. Sorry about the added diff noise.

Please review and merge these changes so that others can benefit.


## Changes
- Updated `lodash` dependency to `4.17.4`
- Replaced `_.pluck()` with `_.map()` as per [Lodash 4.0.0 changelog](https://github.com/lodash/lodash/wiki/Changelog#v400)
- Updated calls to `_.template()` as per [Lodash 4.0.0 changelog](https://github.com/lodash/lodash/wiki/Changelog#v400)